### PR TITLE
chore(renovate): tighten policy with minimumReleaseAge and digest automerge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,18 +3,38 @@
     "config:best-practices"
   ],
   dependencyDashboard: false,
+  minimumReleaseAge: "3 days",
+  lockFileMaintenance: {
+    minimumReleaseAge: null,
+    addLabels: [
+      "automerge"
+    ]
+  },
+  vulnerabilityAlerts: {
+    minimumReleaseAge: null,
+    addLabels: [
+      "automerge"
+    ]
+  },
   packageRules: [
     {
       matchUpdateTypes: [
         "minor",
         "patch",
-        "digest"
+        "digest",
+        "pinDigest"
       ],
       groupName: "all minor, patch, and digest updates",
       groupSlug: "all-minor-patch-digest-updates",
       addLabels: [
         "automerge"
       ]
+    },
+    {
+      matchManagers: [
+        "github-actions"
+      ],
+      minimumReleaseAge: "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add global `minimumReleaseAge: "3 days"` to avoid pulling in unstable releases
- Set `minimumReleaseAge: "7 days"` for GitHub Actions
- Group all `minor`, `patch`, `digest`, and `pinDigest` updates with `automerge` label
- `lockFileMaintenance`: set `minimumReleaseAge: null` and add `automerge` label
- `vulnerabilityAlerts`: set `minimumReleaseAge: null` and add `automerge` label